### PR TITLE
Fix setting basic auth for curl to Inkdrop local server

### DIFF
--- a/src/search.php
+++ b/src/search.php
@@ -17,8 +17,10 @@ class Inkdrop {
   public function search($query) {
     $wf = new Workflows();
 
-    $baseUrl = "http://{$this->username}:{$this->password}@{$this->hostname}:{$this->port}";
-    $json = $wf->request( $baseUrl."/notes/?limit=20&keyword=".urlencode( $query ) );
+    $authOptions = [CURLOPT_USERPWD => "{$this->username}:{$this->password}"];
+
+    $baseUrl = "http://{$this->hostname}:{$this->port}";
+    $json = $wf->request( $baseUrl."/notes/?limit=20&keyword=".urlencode( $query ) , $authOptions);
     $json = json_decode($json);
     $int = 1;
 


### PR DESCRIPTION
Passing `user:password` as part of the url for curl was throwing a formatting error because, at least in my case, the user is an email address.
```
> curl http://some@email.com:password@127.0.0.1:19840/notes/?limit=20&keyword=test
curl: (3) URL using bad/illegal format or missing URL
```
As this has ben deprecated (see [here](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.1)), I switched it to passing the `CURLOPT_USERPWD` option in order to get the workflow working.

Hope it helps. 

Also: This is the related issue -> https://github.com/inkdropapp/inkdrop-alfred-workflow/issues/1