### PR TITLE
Fix json error due to ${var} is deprecated in php 8.2

### DIFF
--- a/src/search.php
+++ b/src/search.php
@@ -29,7 +29,7 @@ class Inkdrop {
       $noteId = $data->{'_id'};
       $bookId = $data->bookId;
       $book = json_decode($wf->request($baseUrl."/".$bookId, $authOptions));
-      $uri = 'inkdrop://'.str_replace(':', '/', "${noteId}");
+      $uri = 'inkdrop://'.str_replace(':', '/', "{$noteId}");
       $wf->result($int.'.'.time(), $uri, $data->title, $book->name, 'icon.png');
       $int++;
     endforeach;


### PR DESCRIPTION
After i update to php 8.2 it seems i unable to search my notes due to *${var} deprecated in php 8.2* 

[Reference](https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated)