### PR TITLE
fix(create-note): use private constant for the default error message

### DIFF
--- a/src/inkdrop.php
+++ b/src/inkdrop.php
@@ -7,7 +7,7 @@ class Inkdrop {
   private $username;
   private $password;
 
-  private $defaultErrorMsg = "Failed to create a new Inkdrop note";
+  private const ERR_MSG_FAILED_TO_CREATE_NOTE = "Failed to create a new Inkdrop note";
 
   function __construct ( $hostname, $port, $username, $password ) {
     $this->hostname = $hostname;
@@ -78,19 +78,19 @@ class Inkdrop {
     $result = json_decode($result);
 
     if ($result == null) {
-      return $this->defaultErrorMsg;
+      return self::ERR_MSG_FAILED_TO_CREATE_NOTE;
     }
 
     if (!$result->{'ok'}) {
       if (str_contains($result->{'error'}, 'invalid tag')) {
-        return "Invalid tag IDs,Please check the tag IDs you specified in your workflow config" ;
+        return "Invalid tag IDs, please check the tag IDs you specified in your workflow config" ;
       }
 
       if (str_contains($result->{'error'}, 'note document')) {
-        return "Failed to create a new Inkdrop note,You have to specify a notebook ID in your workflow config";
+        return "Failed to create a new Inkdrop note, you have to specify a notebook ID in your workflow config";
       }
 
-      return $this->defaultErrorMsg;
+      return self::ERR_MSG_FAILED_TO_CREATE_NOTE;
     }
   }
 }


### PR DESCRIPTION
I guess the default message should be a constant.
I found that PHP supports [Constant Visibility](https://www.php.net/manual/en/language.oop5.visibility.php#language.oop5.visiblity-constants).
@picklecillo Can you review it?