### PR TITLE
handling no body on title:body arg

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -194,9 +194,7 @@ $password = getenv('password');
 
 $inkdrop = new Inkdrop($host, $port, $username, $password);
 
-$args = explode(":", $query, 2);
-$title = $args[0];
-$body = $args[1];
+[$title, $body] = array_pad(explode(":", $query), 2, '');
 
 $tags = getenv('defaultTags');
 $notebook = getenv('defaultNotebook');

--- a/src/inkdrop.php
+++ b/src/inkdrop.php
@@ -59,7 +59,7 @@ class Inkdrop {
         "status" => "active",
         "share" => "private",
         "title" => trim($title),
-        "body" => trim($body) ?? '',
+        "body" => trim($body),
     );
 
     if (!empty($tags)) {


### PR DESCRIPTION
Hey @craftzdog!

Noticed creating a new note with no body like `ink+ title` gets a warning that shows up as a notification.
<img width="390" alt="image" src="https://github.com/user-attachments/assets/b75a8883-0fbf-4b95-a99b-28b7ef2afa57">

From the debugger:
```
Warning: Undefined array key 1 in /Users/picklecillo/Library/Caches/com.runningwithcrayons.Alfred/Workflow Scripts/524CB052-5DDF-40AA-A4E5-BED3DBE86F3E on line 16

Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /Users/picklecillo/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.3950022E-4F14-43AE-8C35-A64FE61E433D/inkdrop.php on line 62
```

to fix it, i'm using `array_pad` so that the expected second argument defaults to an empty string `''` instead of `null`.
